### PR TITLE
Add useEffect hook to hide filter when search query is present

### DIFF
--- a/client/src/pages/ExploreBusiness/index.tsx
+++ b/client/src/pages/ExploreBusiness/index.tsx
@@ -16,7 +16,7 @@ import { UserBusinessList } from "types/business";
 import { FilterData, useBusinessCtx } from "context/BusinessCtx";
 import { IFilter } from "types/business-profile";
 import { cn } from "utils";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const ExploreBusiness = () => {
   const {
@@ -29,6 +29,7 @@ const ExploreBusiness = () => {
     setSearchQuery,
     layout,
     setLayout,
+    searchQuery,
   } = useBusinessCtx();
   const [showFilter, setShowFilter] = useState<boolean>(true);
 
@@ -52,6 +53,12 @@ const ExploreBusiness = () => {
       filters: query,
     });
   };
+
+  useEffect(() => {
+    if (searchQuery) {
+      setShowFilter(false);
+    }
+  }, [searchQuery]);
 
   return (
     <div className="ntw w-full h-full">


### PR DESCRIPTION
Updated the business navigation bug when search query has been applied when trying to move back from business details page.